### PR TITLE
fix: don't trigger label edition on shift click

### DIFF
--- a/src/OCLnmr.tsx
+++ b/src/OCLnmr.tsx
@@ -112,6 +112,7 @@ export default function OCLnmr(props: OCLnmrProps) {
         setHoverAtom();
         toggleHydrogens(molecule, atomID);
         setMolfile(molecule.toMolfileV3());
+        event.preventDefault();
       }
     },
     onChange: setMolfile,


### PR DESCRIPTION
Closes: https://github.com/zakodium-oss/react-ocl-nmr/issues/35